### PR TITLE
docs: missing backtick in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple helper package to turn Serverless Framework into a Server Side Renderin
 ### Setup
 - Create a folder in your root named ``/templates``.
 - Create your html files to use as templates in the ``/templates`` folder.
-- Create a folder in your root named ``/styles`.
+- Create a folder in your root named ``/styles``.
 - Create your css files in the ``/styles`` folder.
 - Name your css files the same as your html files (file extension will be different of course)
 


### PR DESCRIPTION
code block in line 10 wasn't being rendered due to missing backtick