### PR TITLE
Added ability to customize headers on the http method in response.js.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ const { response } = require('simple-sls-ssr')
 
 module.exports.myfunction = async (event, context) => {
   const body = { success: "hello world!" }
-  return response.http(200, body)
+  const customHeaders = { "myCookie" : "Cookie123"}
+  return response.http(200, body, customHeaders)
 }
 ```

--- a/modules/response.js
+++ b/modules/response.js
@@ -2,11 +2,12 @@
 
 /**
  * @description Formats the http response for the http functions.
- * @param {integer} statusCode
- * @param {object} body
+ * @param {integer} statusCode Number representing http status code.
+ * @param {object} body Body json data.
+ * @param {object} headers Custom html headers you want to add.
  * @returns {object} Http return data.
  */
-module.exports.http = (statusCode, body) => {
+module.exports.http = (statusCode, body, headers = {}) => {
   const returnData = {
     statusCode: statusCode,
     headers: {
@@ -18,6 +19,10 @@ module.exports.http = (statusCode, body) => {
       'Cache-Control': 'no-store',
       'Clear-Site-Data': '*'
     }
+  }
+
+  if (Object.keys(headers).length) {
+    returnData.headers = { ...returnData.headers, ...headers }
   }
 
   if (body) {

--- a/tests/response.tests.js
+++ b/tests/response.tests.js
@@ -50,6 +50,33 @@ test('Test generate return data with 200 htttp code and body', t => {
   t.end()
 })
 
+test('Test generating http response with custom headers.', async t => {
+  const headers = {
+    'Set-Cookie': 'mycookie=123'
+  }
+  const response = await http(200, {}, headers)
+
+  const expected = {
+    statusCode: 200,
+    headers: {
+      'Set-Cookie': 'mycookie=123',
+      'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload',
+      'Content-Security-Policy': 'default-src "self"',
+      'X-Frame-Options': 'deny',
+      'X-Content-Type-Options': 'nosniff',
+      'Referrer-Policy': 'origin-when-cross-origin',
+      'Cache-Control': 'no-store',
+      'Clear-Site-Data': '*'
+    },
+    body: '{}'
+
+  }
+
+  t.deepEquals(response, expected, 'Renders the correct information.')
+
+  t.end()
+})
+
 test('Test generating a redirect response.', async t => {
   const response = await redirect('./mypage')
 


### PR DESCRIPTION
Co-authored-by: Damien Richcreek <Damien@Richcreek.dev>
Co-authored-by: Zach Grammon <zachgrammon@gmail.com>
Co-authored-by: Amber Kim <hello@ambergkim.com>

Why:
Other methods could do it and we are bringing it in line with the other methods

Changes:
- Added headers param to http methods.
- Merged custom headers into existing default headers.
- Updated README.
- Updated test.